### PR TITLE
BUG: waitpid() busy loop

### DIFF
--- a/tests/3_children.sh
+++ b/tests/3_children.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+(sleep 1 && exit)&
+(sleep 100 && exit)&
+exit


### PR DESCRIPTION
Once waitpid returns, we enter a busy loop waiting for more children,
even after it returns 0 which indicates that there are no more children.

Signals are no longer forwarded.

This change addresses the issue. Manually tested with
tests/3_children.sh.

Closes #5.
